### PR TITLE
Add banner and navigation highlight

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import './styles/App.css';
-import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, NavLink } from 'react-router-dom';
 import About from './pages/About';
 import Career from './pages/Career';
 import Interests from './pages/Interests';
@@ -11,11 +11,25 @@ function App() {
     <Router>
       <div className="window">
         <div className="window-body">
+          <div className="banner">
+            <img
+              src="https://images.unsplash.com/photo-1503264116251-35a269479413?auto=format&fit=crop&w=1350&q=80"
+              alt="Retro landscape banner"
+            />
+          </div>
           <menu role="tablist">
-            <li role="tab"><Link to="/">About</Link></li>
-            <li role="tab"><Link to="/career">Career</Link></li>
-            <li role="tab"><Link to="/interests">Interests</Link></li>
-            <li role="tab"><Link to="/blog">Blog</Link></li>
+            <li role="tab">
+              <NavLink to="/" end className={({ isActive }) => isActive ? 'active' : ''}>About</NavLink>
+            </li>
+            <li role="tab">
+              <NavLink to="/career" className={({ isActive }) => isActive ? 'active' : ''}>Career</NavLink>
+            </li>
+            <li role="tab">
+              <NavLink to="/interests" className={({ isActive }) => isActive ? 'active' : ''}>Interests</NavLink>
+            </li>
+            <li role="tab">
+              <NavLink to="/blog" className={({ isActive }) => isActive ? 'active' : ''}>Blog</NavLink>
+            </li>
           </menu>
 
           <div className="window" role="tabpanel">

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -24,6 +24,19 @@ body,
   background-image: url('https://www.transparenttextures.com/patterns/paper.png');
 }
 
+.banner img {
+  width: 100%;
+  height: 120px;
+  object-fit: cover;
+  display: block;
+}
+
+menu[role="tablist"] li a.active {
+  background-color: navy;
+  color: white;
+  padding: 0 4px;
+}
+
 .blog-container {
   display: flex;
   height: 100%;


### PR DESCRIPTION
## Summary
- add a banner image above tabs
- highlight active tab using `NavLink`

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68439faf12e0832aa316fdb6d31e45e5