### PR TITLE
Fix layout scrolling and blog list height

### DIFF
--- a/frontend/src/components/BlogList.tsx
+++ b/frontend/src/components/BlogList.tsx
@@ -1,19 +1,36 @@
-import React, { useState } from 'react';
+import React, { useLayoutEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { blogs } from '../data/blogs';
 
-interface BlogListProps {
-  postsPerPage?: number;
-}
-
-const BlogList: React.FC<BlogListProps> = ({ postsPerPage = 3 }) => {
+const BlogList: React.FC = () => {
+  const listRef = useRef<HTMLDivElement>(null);
+  const [postsPerPage, setPostsPerPage] = useState(blogs.length);
   const [page, setPage] = useState(0);
+
+  useLayoutEffect(() => {
+    const updateCounts = () => {
+      const container = listRef.current;
+      if (!container) return;
+      const firstItem = container.querySelector('li');
+      const pagination = container.querySelector('.pagination') as HTMLElement | null;
+      if (!firstItem) return;
+      const itemHeight = firstItem.getBoundingClientRect().height;
+      const paginationHeight = pagination ? pagination.getBoundingClientRect().height : 0;
+      const available = container.clientHeight - paginationHeight;
+      const count = Math.floor(available / itemHeight);
+      setPostsPerPage(count > 0 ? Math.min(count, blogs.length) : blogs.length);
+    };
+    updateCounts();
+    window.addEventListener('resize', updateCounts);
+    return () => window.removeEventListener('resize', updateCounts);
+  }, []);
+
   const start = page * postsPerPage;
   const visible = blogs.slice(start, start + postsPerPage);
   const totalPages = Math.ceil(blogs.length / postsPerPage);
 
   return (
-    <div className="blog-list">
+    <div className="blog-list" ref={listRef}>
       <ul>
         {visible.map(post => (
           <li key={post.slug} className="blog-item">
@@ -22,11 +39,13 @@ const BlogList: React.FC<BlogListProps> = ({ postsPerPage = 3 }) => {
           </li>
         ))}
       </ul>
-      <div className="pagination">
-        <button disabled={page === 0} onClick={() => setPage(p => p - 1)}>Prev</button>
-        <span>{page + 1} / {totalPages}</span>
-        <button disabled={page + 1 >= totalPages} onClick={() => setPage(p => p + 1)}>Next</button>
-      </div>
+      {totalPages > 1 && (
+        <div className="pagination">
+          <button disabled={page === 0} onClick={() => setPage(p => p - 1)}>Prev</button>
+          <span>{page + 1} / {totalPages}</span>
+          <button disabled={page + 1 >= totalPages} onClick={() => setPage(p => p + 1)}>Next</button>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -8,6 +8,8 @@ body,
   padding: 0;
   height: 100%;
   width: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 /* 2) Span the .window element to the full viewport */
@@ -17,6 +19,7 @@ body,
   left: 0;
   width: 100vw;
   height: 100vh;
+  box-sizing: border-box;
   box-shadow: 2px 2px 0px #000;
   border: 2px outset gray;
   overflow: auto;
@@ -39,8 +42,18 @@ body,
   width: 250px;
   border-left: 2px inset gray;
   padding: 0.5rem;
-  overflow-y: auto;
   background-color: #f0f0f0;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  box-sizing: border-box;
+}
+
+.blog-list ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  flex: 1 1 auto;
 }
 
 .blog-item {
@@ -58,4 +71,5 @@ body,
   display: flex;
   justify-content: space-between;
   margin-top: 0.5rem;
+  flex-shrink: 0;
 }


### PR DESCRIPTION
## Summary
- prevent body scrollbars and box-size windows
- allow blog list to use available height and hide pagination unless needed
- allow vertical scroll for long content

## Testing
- `npm test -- -w=1`


------
https://chatgpt.com/codex/tasks/task_e_68439e59de9c832a90658b5580a8dc5f