### PR TITLE
Fix icon import build errors

### DIFF
--- a/frontend/src/images.d.ts
+++ b/frontend/src/images.d.ts
@@ -1,0 +1,4 @@
+declare module '*.png' {
+  const src: string;
+  export default src;
+}


### PR DESCRIPTION
## Summary
- add images.d.ts to declare PNG modules for TypeScript

## Testing
- `npm run build`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6843a4d0130c832aa4fc755a5961c4dd