### PR TITLE
Remove tab shadow for active tab

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,11 @@
 import './styles/App.css';
-import { BrowserRouter as Router, Routes, Route, NavLink } from 'react-router-dom';
+import {
+  BrowserRouter as Router,
+  Routes,
+  Route,
+  NavLink,
+  useMatch,
+} from 'react-router-dom';
 import About from './pages/About';
 import Career from './pages/Career';
 import Interests from './pages/Interests';
@@ -14,57 +20,68 @@ import notepadIcon from './styles/icons/notepad.png';
 function App() {
   return (
     <Router>
-      <div className="window">
-        <div className="window-body">
-          <div className="banner">
-            <img
-              src="https://images.unsplash.com/photo-1503264116251-35a269479413?auto=format&fit=crop&w=1350&q=80"
-              alt="Retro landscape banner"
-            />
-          </div>
-          <menu role="tablist">
-            <li role="tab">
-              <NavLink to="/" end className={({ isActive }) => isActive ? 'active' : ''}>
-                <img src={windowIcon} alt="About icon" className="menu-icon" />
-                About
-              </NavLink>
-            </li>
-            <li role="tab">
-              <NavLink to="/career" className={({ isActive }) => isActive ? 'active' : ''}>
-                <img src={folderIcon} alt="Career icon" className="menu-icon" />
-                Career
-              </NavLink>
-            </li>
-            <li role="tab">
-              <NavLink to="/interests" className={({ isActive }) => isActive ? 'active' : ''}>
-                <img src={computerIcon} alt="Interests icon" className="menu-icon" />
-                Interests
-              </NavLink>
-            </li>
-            <li role="tab">
-              <NavLink to="/blog" className={({ isActive }) => isActive ? 'active' : ''}>
-                <img src={notepadIcon} alt="Blog icon" className="menu-icon" />
-                Blog
-              </NavLink>
-            </li>
-          </menu>
+      <AppContent />
+    </Router>
+  );
+}
 
-          <div className="window" role="tabpanel">
-            <div className="window-body">
-              <Routes>
-                <Route path="/" element={<About />} />
-                <Route path="/career" element={<Career />} />
-                <Route path="/interests" element={<Interests />} />
-                <Route path="/blog" element={<BlogLayout />}> 
-                  <Route index element={<div className="blog-content"><p>Select a blog.</p></div>} />
-                  <Route path=":slug" element={<BlogPost />} />
-                </Route>
-              </Routes>
-            </div>
+function AppContent() {
+  const aboutMatch = useMatch({ path: '/', end: true });
+  const careerMatch = useMatch('/career');
+  const interestsMatch = useMatch('/interests');
+  const blogMatch = useMatch('/blog');
+
+  return (
+    <div className="window">
+      <div className="window-body">
+        <div className="banner">
+          <img
+            src="https://images.unsplash.com/photo-1503264116251-35a269479413?auto=format&fit=crop&w=1350&q=80"
+            alt="Retro landscape banner"
+          />
+        </div>
+        <menu role="tablist">
+          <li role="tab" aria-selected={aboutMatch ? 'true' : undefined} className={aboutMatch ? 'selected-tab' : undefined}>
+            <NavLink to="/" end className={({ isActive }) => (isActive ? 'active' : '')}>
+              <img src={windowIcon} alt="About icon" className="menu-icon" />
+              About
+            </NavLink>
+          </li>
+          <li role="tab" aria-selected={careerMatch ? 'true' : undefined} className={careerMatch ? 'selected-tab' : undefined}>
+            <NavLink to="/career" className={({ isActive }) => (isActive ? 'active' : '')}>
+              <img src={folderIcon} alt="Career icon" className="menu-icon" />
+              Career
+            </NavLink>
+          </li>
+          <li role="tab" aria-selected={interestsMatch ? 'true' : undefined} className={interestsMatch ? 'selected-tab' : undefined}>
+            <NavLink to="/interests" className={({ isActive }) => (isActive ? 'active' : '')}>
+              <img src={computerIcon} alt="Interests icon" className="menu-icon" />
+              Interests
+            </NavLink>
+          </li>
+          <li role="tab" aria-selected={blogMatch ? 'true' : undefined} className={blogMatch ? 'selected-tab' : undefined}>
+            <NavLink to="/blog" className={({ isActive }) => (isActive ? 'active' : '')}>
+              <img src={notepadIcon} alt="Blog icon" className="menu-icon" />
+              Blog
+            </NavLink>
+          </li>
+        </menu>
+
+        <div className="window" role="tabpanel">
+          <div className="window-body">
+            <Routes>
+              <Route path="/" element={<About />} />
+              <Route path="/career" element={<Career />} />
+              <Route path="/interests" element={<Interests />} />
+              <Route path="/blog" element={<BlogLayout />}>
+                <Route index element={<div className="blog-content"><p>Select a blog.</p></div>} />
+                <Route path=":slug" element={<BlogPost />} />
+              </Route>
+            </Routes>
           </div>
         </div>
       </div>
-    </Router>
+    </div>
   );
 }
 

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -47,6 +47,10 @@ menu[role="tablist"] li a.active {
   padding: 0 4px;
 }
 
+menu[role="tablist"] li.selected-tab {
+  box-shadow: inset -1px 0 #0a0a0a, inset -2px 0 grey;
+}
+
 .blog-container {
   display: flex;
   height: 100%;


### PR DESCRIPTION
## Summary
- compute active tab using `useMatch`
- add `selected-tab` class to active tabs
- strip box shadow for the selected tab

## Testing
- `npm run build`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686af6ac64e0832aa13963f840bc445f